### PR TITLE
fix($common) : Fix YAML Load Warning

### DIFF
--- a/$common/fragments/config.py
+++ b/$common/fragments/config.py
@@ -30,7 +30,7 @@ def config_file_to_dict(file_path):
 
         with open(file_path, "r") as stream:
             # File must not be empty
-            load_config = yaml.load(stream)
+            load_config = yaml.safe_load(stream)
             # If no file given
             if load_config is None:
                 return default_values


### PR DESCRIPTION
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated