### PR TITLE
Better Compilation warnings

### DIFF
--- a/$common/fragments/extraction.py
+++ b/$common/fragments/extraction.py
@@ -87,14 +87,13 @@ def extract_compilation_errors(javac_result):
         helper.relative_path(PATH_FLAVOUR)
     ]
     # because Inginious is on Linux; the separator will never change
-    separator = "/"
+    separator = '/' if '/' in PATH_SRC else '\\'
 
     # regexs
     regex_errors = re.compile("[0-9]+ errors?")
     regex_first_message = re.compile(
         "^{}{}{}:{}:\s{}$".format(
-            "(?P<folder>{})"
-                .format("|".join(folders)),
+            "(?P<folder>{})".format("|".join(folders)),
             "\/" if separator == "/" else "\\",
             "(?P<filename>.*\.java)",
             "(?P<line_number>[0-9]+)",

--- a/$common/fragments/extraction.py
+++ b/$common/fragments/extraction.py
@@ -1,5 +1,6 @@
 import re
 
+from fragments.constants import *
 from fragments import coverage, helper
 
 
@@ -75,3 +76,57 @@ def extract_jacoco_result(feedback_settings):
         ratio = covered / total if total > 0 else 0.0
 
         return ratio, msg
+
+
+# Extract errors from javac result
+def extract_compilation_errors(javac_result):
+    lines = javac_result.splitlines()
+    folders = [
+        helper.relative_path(PATH_SRC),
+        helper.relative_path(PATH_TEMPLATES),
+        helper.relative_path(PATH_FLAVOUR)
+    ]
+    # because Inginious is on Linux; the separator will never change
+    separator = "/"
+
+    # regexs
+    regex_errors = re.compile("[0-9]+ errors?")
+    regex_first_message = re.compile(
+        "^{}{}{}:{}:\s{}$".format(
+            "(?P<folder>{})"
+                .format("|".join(folders)),
+            "\/" if separator == "/" else "\\",
+            "(?P<filename>.*\.java)",
+            "(?P<line_number>[0-9]+)",
+            "(?P<message>.*)"
+        )
+    )
+
+    # variables that will be used somewhere in the loop
+    errors = []
+
+    for line in lines:
+        # ignores line that contains the sum of errors
+        if regex_errors.match(line):
+            continue
+
+        # when the regex matches, we are on the first line that explain the problem
+        if regex_first_message.match(line):
+            matches = re.search(regex_first_message, line)
+            # save for later use
+            errors.append({
+                "source": matches.group("folder"),
+                "file": matches.group("filename"),
+                "line": matches.group("line_number"),
+                "message": matches.group("message"),
+                "code": []
+            })
+
+        # else, we must store the code sample provided by javac
+        else:
+            # append the line to the code array
+            errors[-1].update({
+                "code": [*errors[-1].get("code"), line]
+            })
+
+    return errors

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -43,7 +43,7 @@ def compilation_feedback(result):
             msg += " " * indentation + ":widths: auto" + next_line * 2
 
             # Contents
-            for error in errors:
+            for error in [error for error in errors if error.get("source", "Unknown Source") == templates_folder]:
                 # Print File , Line and Error message without problem
                 msg += " " * indentation + "§{}§".format(error.get("file", "Unknown Filename"))
                 msg += ",§{}§".format(error.get("line", "Unknown Line Number"))

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -2,16 +2,45 @@ import sys
 
 from inginious import feedback, rst
 
-
 from fragments import helper
 from fragments.extraction import *
+
+
+# Throw a fatal error if we cannot create the jar
+def jar_feedback(result):
+    if result.returncode != 0:
+        msg = "A technical problem has occurred: please report it !"
+        print(result.stderr)
+        feedback.set_global_feedback(msg)
+        feedback.set_global_result("failed")
+        feedback.set_grade(0.0)
+        sys.exit(0)
 
 
 # Throw a fatal error if the given code doesn't compile
 def compilation_feedback(result):
     if result.returncode != 0:
+        errors = extract_compilation_errors(result.stderr)
+
+        # Generate the RST
+        msg = ""
+        next_line = "\n\r"
+
+        # Headers
+        msg += ".. csv-table:: Compilations errors" + next_line
+        msg += " " * 4 + ":header: " + ",".join(["\"{}\"".format(item)
+                                                 for item in ["File", "Line", "Error Message", "Code"]]) + next_line
+        msg += " " * 4 + ":widths: auto" + next_line * 2
+
+        # Contents
+        for error in errors:
+            print(error)
+
+        # Send it to Inginious
+
         msg = "Your file did not compile : please don't use INGINIOUS as an IDE ..."
         print(result.stderr)
+        # \n\r à rajouter
         feedback.set_global_feedback(msg)
         feedback.set_global_result("failed")
         feedback.set_grade(0.0)

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -30,7 +30,8 @@ def compilation_feedback(result):
         if any(error.get("source", "templates") == templates_folder for error in errors):
             # Generate an custom RST report that will see the student
             msg = ""
-            next_line = "\n\r"
+            # Don't add \r to that as it produces strange results
+            next_line = "\n"
             indentation = 4
             headers = ["File", "Line", "Error Message", "Code"]
 
@@ -42,8 +43,6 @@ def compilation_feedback(result):
             msg += " " * indentation + ":widths: auto" + next_line * 2
 
             # Contents
-            # TODO Pas encore au point ; je continues à tête reposé plus tard
-            # TODO Cependant, on se rapproche de la solution selon mon REPL XD
             for error in errors:
                 # Print File , Line and Error message without problem
                 msg += " " * indentation + "§{}§".format(error.get("file", "Unknown Filename"))

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -66,9 +66,7 @@ def compilation_feedback(result):
                 msg += "§" + next_line
 
             # Send it to Inginious
-            # TODO Code Temporaire
-            #  C'est du RST ; je dois relire la doc du rst code sur Inginious
-            feedback.set_global_feedback(msg)
+            feedback.set_global_feedback(msg, True)
 
         else:
 

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -2,6 +2,7 @@ import sys
 
 from inginious import feedback, rst
 
+
 from fragments import helper
 from fragments.extraction import *
 

--- a/$common/runfile.py
+++ b/$common/runfile.py
@@ -75,8 +75,8 @@ def main():
     print("COMPILING CODE : {}".format(compile_cmd))
     result = helper.run_command(compile_cmd)
 
-    # handle compilation errors
-    feedback.compilation_feedback(result)
+    # handle jar creation errors
+    feedback.jar_feedback(result)
 
     #####################################
     #       GENERATE A JAR FILE         #

--- a/$common/runfile.py
+++ b/$common/runfile.py
@@ -75,8 +75,8 @@ def main():
     print("COMPILING CODE : {}".format(compile_cmd))
     result = helper.run_command(compile_cmd)
 
-    # handle jar creation errors
-    feedback.jar_feedback(result)
+    # handle compilation errors
+    feedback.compilation_feedback(result)
 
     #####################################
     #       GENERATE A JAR FILE         #
@@ -95,8 +95,8 @@ def main():
     # For debug the jar construction
     # print(result.stdout)
 
-    # handle compilation errors
-    feedback.compilation_feedback(result)
+    # handle jar creation errors
+    feedback.jar_feedback(result)
 
     #####################################
     #   RUN  TEST  RUNNER               #


### PR DESCRIPTION
As seen in permanencies, when the provided code doesn't compile, INGINIOUS currently gives him the following message : 

![image](https://user-images.githubusercontent.com/9306961/65760184-c4499000-e11c-11e9-8c8b-e86268a766ce.png)

Whereas some errors are quite obvious in the student code, others are not. 

To help our students / assistants / tutors / professors, the code introduces a better visual representation in the same style as IDE's.

![image](https://user-images.githubusercontent.com/9306961/65760571-8c8f1800-e11d-11e9-87f7-576bc91cdd05.png)

( This table only shows the relevant errors for the student )