### PR TITLE
Fix some mistakes in CimplexityMCQ1

### DIFF
--- a/ComplexityMCQ1/task.yaml
+++ b/ComplexityMCQ1/task.yaml
@@ -105,7 +105,6 @@ problems:
     mcq4:
         choices:
         -   text: :math:`\mathcal{O}(n)`
-            valid: true
         -   text: :math:`\mathcal{O}(n^2)`
         -   text: :math:`\Theta(n)`
             valid: true

--- a/ComplexityMCQ1/task.yaml
+++ b/ComplexityMCQ1/task.yaml
@@ -104,14 +104,14 @@ problems:
         multiple: true
     mcq4:
         choices:
-        -   valid: true
-            text: :math:`\mathcal{O}(n)`
+        -   text: :math:`\mathcal{O}(n)`
+		    valid: true
         -   text: :math:`\mathcal{O}(n^2)`
         -   text: :math:`\Theta(n)`
-        -   text: :math:`\Theta(log(n))`
-        -   valid: true
-            text: :math:`\Omega(1)`
-        -   text: :math:`\Omega(log(n))`
+		    valid: true
+        -   text: :math:`\Theta(\log(n))`
+        -   text: :math:`\Omega(1)`
+        -   text: :math:`\Omega(\log(n))`
         header: You write a function to verify if a list of length :math:`n` is ordered
             or not, this function returns true if it is and false if it is'nt. What
             is (are) the most precise time complexity(ies)?
@@ -147,9 +147,8 @@ problems:
         -   text: :math:`0.00001 \in \Theta(1)`
             valid: true
         -   text: :math:`2^{2n} \in \mathcal{O}(2^n)`
-            valid: true
         -   text: :math:`3^n \in \mathcal{O}(2^n)`
-        -   text: :math:`n log(n) \in \mathcal{O}(n)`
+        -   text: :math:`n \log(n) \in \mathcal{O}(n)`
         type: multiple_choice
         name: Mathematical Functions and Time Complexity
         header: 'Select the right proposition(s) :'

--- a/ComplexityMCQ1/task.yaml
+++ b/ComplexityMCQ1/task.yaml
@@ -105,10 +105,10 @@ problems:
     mcq4:
         choices:
         -   text: :math:`\mathcal{O}(n)`
-		    valid: true
+	    valid: true
         -   text: :math:`\mathcal{O}(n^2)`
         -   text: :math:`\Theta(n)`
-		    valid: true
+            valid: true
         -   text: :math:`\Theta(\log(n))`
         -   text: :math:`\Omega(1)`
         -   text: :math:`\Omega(\log(n))`

--- a/ComplexityMCQ1/task.yaml
+++ b/ComplexityMCQ1/task.yaml
@@ -105,7 +105,7 @@ problems:
     mcq4:
         choices:
         -   text: :math:`\mathcal{O}(n)`
-	    valid: true
+            valid: true
         -   text: :math:`\mathcal{O}(n^2)`
         -   text: :math:`\Theta(n)`
             valid: true


### PR DESCRIPTION
J'ai repéré 2 erreurs faciles à corriger en faisant le QCM donc voilà la correction. J'en ai profité pour écrire \log en LaTeX, c'est quand même plus joli!

Les erreurs:
- 2^2n n'est pas O(2^n) puisque le quotient de ces fonctions (2^n) n'est pas borné
- Je ne vois pas avec quel algorithme on peut établir qu'une liste est triée en Omega(1)... :-)

~ Bruno