### PR TITLE
feat($common) : allows to specify custom xpath rules for coverage 🚧

### DIFF
--- a/$common/fragments/config.py
+++ b/$common/fragments/config.py
@@ -10,6 +10,7 @@ def config_file_to_dict(file_path):
         "quorum": 1.0,
         "feedback_kind": None,
         "coverage_stats": None,
+        "coverage_xpaths": ["./counter"]
         "prohibited": {},
         "required": {},
         "plagiarism": False,

--- a/$common/fragments/coverage.py
+++ b/$common/fragments/coverage.py
@@ -6,7 +6,7 @@ combine_list = chain.from_iterable
 
 # https://docs.python.org/3/library/xml.etree.elementtree.html
 # Extract the stats given by Jacoco into a list so that we can use that later
-def extract_stats(path_to_xml_file=JACOCO_RESULT_FILE, xpaths):
+def extract_stats(xpaths, path_to_xml_file=JACOCO_RESULT_FILE):
     tree = ET.parse(path_to_xml_file)
     root = tree.getroot()
     return [

--- a/$common/fragments/coverage.py
+++ b/$common/fragments/coverage.py
@@ -1,10 +1,12 @@
 from xml.etree import ElementTree as ET
 from fragments.constants import *
+from itertools import chain
+combine_list = chain.from_iterable
 
 
 # https://docs.python.org/3/library/xml.etree.elementtree.html
 # Extract the stats given by Jacoco into a list so that we can use that later
-def extract_stats(path_to_xml_file=JACOCO_RESULT_FILE):
+def extract_stats(path_to_xml_file=JACOCO_RESULT_FILE, xpaths):
     tree = ET.parse(path_to_xml_file)
     root = tree.getroot()
     return [
@@ -13,7 +15,12 @@ def extract_stats(path_to_xml_file=JACOCO_RESULT_FILE):
             "missed": int(coverage_data.get("missed")),
             "type": coverage_data.get("type")
         }
-        for coverage_data in root.findall("./counter")
+        for coverage_data in
+            combine_list([
+                root.findall(xpath_rule)
+                for xpath_rule
+                in xpaths
+            ])
     ]
 
 

--- a/$common/fragments/extraction.py
+++ b/$common/fragments/extraction.py
@@ -56,7 +56,7 @@ def extract_jacoco_result(feedback_settings):
         helper.run_command(gen_report)
 
         # extract stats
-        coverage_result = coverage.extract_stats()
+        coverage_result = coverage.extract_stats(xpaths=feedback_settings["coverage_xpaths"])
         filtered_coverage_result = [x for x in coverage_result if x["type"] in coverage_stats]
         print(filtered_coverage_result)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ services:
   - mongodb
   - docker
 install:
-  # TODO DONT USE THE REAL INGINIOUS VERSION AS THEY DONT MERGE THIS PR :
-  # https://github.com/UCL-INGI/INGInious/pull/415
-  # - pip3 install git+https://github.com/UCL-INGI/INGInious
-  - pip3 install git+https://github.com/jy95/INGInious
+  - pip3 install git+https://github.com/UCL-INGI/INGInious
   - docker pull ingi/inginious-c-base
   - docker pull ingi/inginious-c-default
   - docker pull ingi/inginious-c-java8scala

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -65,7 +65,7 @@ def validations(feedback_settings, folder, items_in_task):
             return text_with_color("coverage_xpaths should be a sequence of string", 196) + "\n"
         else:
             if any(
-                    [(not isinstance(item, str))]
+                    [(not isinstance(item, str))
                      for item in feedback_settings["coverage_xpaths"]]
             ):
                 return text_with_color("Unknown value inside coverage_xpaths", 196) + "\n"
@@ -144,7 +144,7 @@ def validations(feedback_settings, folder, items_in_task):
         verification_result("feedback_kind", feedback_kind_check),
         verification_result("quorum", quorum_check),
         verification_result("coverage_stats", coverage_stats_check),
-        verification_result("coverage_xpaths", coverage_xpaths_check)
+        verification_result("coverage_xpaths", coverage_xpaths_check),
         verification_result("prohibited", statement_presence_check("prohibited")),
         verification_result("required", statement_presence_check("required")),
         verification_result("plagiarism", plagiarism_check),

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -60,6 +60,18 @@ def validations(feedback_settings, folder, items_in_task):
             else:
                 return ""
 
+    def coverage_xpaths_check():
+        if not isinstance(feedback_settings["coverage_xpaths"], list):
+            return text_with_color("coverage_xpaths should be a sequence of string", 196) + "\n"
+        else:
+            if any(
+                    [(not isinstance(item, str))]
+                     for item in feedback_settings["coverage_xpaths"]]
+            ):
+                return text_with_color("Unknown value inside coverage_xpaths", 196) + "\n"
+            else:
+                return ""
+
     def statement_presence_check(statement_kind):
         def checker():
             if not isinstance(feedback_settings[statement_kind], dict):
@@ -132,6 +144,7 @@ def validations(feedback_settings, folder, items_in_task):
         verification_result("feedback_kind", feedback_kind_check),
         verification_result("quorum", quorum_check),
         verification_result("coverage_stats", coverage_stats_check),
+        verification_result("coverage_xpaths", coverage_xpaths_check)
         verification_result("prohibited", statement_presence_check("prohibited")),
         verification_result("required", statement_presence_check("required")),
         verification_result("plagiarism", plagiarism_check),


### PR DESCRIPTION
Hello LEPL1402,

For some exercises using [JaCoCo](https://www.eclemma.org/jacoco/) (like [Coverage](https://github.com/UCL-INGI/LEPL1402/tree/master/Coverage)), it may be useful to specify advanced xpath(s) for the [report](https://www.jacoco.org/jacoco/trunk/coverage/report.dtd) in **XML** to better compute what should be covered (or not), instead of relying on the "total" count : it is now possible with the new key `coverage_xpaths` in [feedback_settings.yaml page](https://github.com/UCL-INGI/LEPL1402/wiki/FAQ-on-feedback_settings.yaml) : 

For example : 
```yml
has_feedback: true
quorum: 0.65
feedback_kind: JaCoCo
coverage_stats:
  - INSTRUCTION
  - BRANCH
coverage_xpaths:
  - xpath1
  - xpath2
```

If not specified, the used value will be the previously one used in the code ( `["./counter"]` )

Checklist :
✔️ add tests in check_requirements.py
✔️ add code that doesn't break backwards 
❌ add documentation about that in [feedback_settings.yaml page](https://github.com/UCL-INGI/LEPL1402/wiki/FAQ-on-feedback_settings.yaml)
🚧 need to be tested in real life : since Inginious seems to have some problems with the [java8scala environment](https://github.com/UCL-INGI/INGInious-containers/tree/master/grading/java8scala), whatever the version I used (v5 or v6), cannot test myself 👎  

