### PR TITLE
refactor(feedback.py) : compilation_feedback 🚧

### DIFF
--- a/$common/fragments/config.py
+++ b/$common/fragments/config.py
@@ -15,6 +15,8 @@ def config_file_to_dict(file_path):
         "plagiarism": False,
         "external_libraries": None,
         "custom_feedback_script": None,
+        "username_for_full_log": None,
+        "full_log": False,
         "status_message": {
             0: "Your code has successfully passed all tests for this mission.",
             1: "Your code failed all tests for this mission.",

--- a/$common/fragments/config.py
+++ b/$common/fragments/config.py
@@ -16,7 +16,6 @@ def config_file_to_dict(file_path):
         "external_libraries": None,
         "custom_feedback_script": None,
         "username_for_full_log": None,
-        "full_log": False,
         "status_message": {
             0: "Your code has successfully passed all tests for this mission.",
             1: "Your code failed all tests for this mission.",

--- a/$common/fragments/config.py
+++ b/$common/fragments/config.py
@@ -15,7 +15,7 @@ def config_file_to_dict(file_path):
         "plagiarism": False,
         "external_libraries": None,
         "custom_feedback_script": None,
-        "username_for_full_log": None,
+        "usernames_for_full_log": [],
         "status_message": {
             0: "Your code has successfully passed all tests for this mission.",
             1: "Your code failed all tests for this mission.",

--- a/$common/fragments/feedback.py
+++ b/$common/fragments/feedback.py
@@ -20,7 +20,7 @@ def jar_feedback(result):
 
 
 # Throw a fatal error if the given code doesn't compile
-def compilation_feedback(result):
+def compilation_feedback(result, full_log):
     if result.returncode != 0:
         errors = extract_compilation_errors(result.stderr)
 
@@ -34,17 +34,26 @@ def compilation_feedback(result):
             feedback.set_global_feedback(msg, True)
 
         else:
+            
+            if full_log:
+                
+                # A teaching assitant wants to debug this task and no error is coming from template folder
+                msg = generate_compilation_errors_table(errors, [PATH_SRC, PATH_FLAVOUR])
 
-            # Either the student has made mistake(s) eg in the signature(s) of method(s) ....
-            # Or a TA adds code that doesn't compile
-            feedback.set_global_feedback(
-                "{}{}".format(
-                    "You modified the signature of at least a function or modified the content of a class.",
-                    "You should not; the tests fail to compile"
-                ))
+                # Send it to Inginious
+                feedback.set_global_feedback(msg, True)
 
-            # For debug purposes ; if the student code isn't to blame
-            print(result.stderr)
+                # For debug purposes
+                print(result.stderr)
+            else:
+
+                # Either the student has made mistake(s) eg in the signature(s) of method(s) ....
+                # Or a TA adds code that doesn't compile
+                feedback.set_global_feedback(
+                    "{}{}".format(
+                        "You modified the signature of at least a function or modified the content of a class.",
+                        "You should not; the tests fail to compile"
+                    ))
 
         # Final instructions commons for all scenario
 

--- a/$common/runfile.py
+++ b/$common/runfile.py
@@ -80,7 +80,7 @@ def main():
 
     # handle compilation errors
     # For teaching assistant that test some tasks might want the full feedback
-    full_log = username == config["username_for_full_log"]
+    full_log = username in feedback_settings["usernames_for_full_log"]
     feedback.compilation_feedback(result, full_log)
 
     #####################################

--- a/$common/runfile.py
+++ b/$common/runfile.py
@@ -11,6 +11,9 @@ from fragments.constants import *
 
 
 def main():
+
+    username = input.get_input("@username")
+
     #####################################
     #   Load feedback task settings     #
     #####################################
@@ -76,7 +79,9 @@ def main():
     result = helper.run_command(compile_cmd)
 
     # handle compilation errors
-    feedback.compilation_feedback(result)
+    # For teaching assistant that test some tasks might want the full feedback
+    full_log = config["has_feedback"] and username == config["username_for_full_log"]
+    feedback.compilation_feedback(result, full_log)
 
     #####################################
     #       GENERATE A JAR FILE         #
@@ -124,14 +129,12 @@ def main():
     #####################################
     if feedback_settings["plagiarism"]:
 
-        student_name = input.get_input("@username")
-
         # The files filled by the student are all inside PATH_TEMPLATES
         files_to_be_tested = helper.find_files_in_path(PATH_TEMPLATES)
 
         # Creates the archive like expected by JPlag
         for student_file in files_to_be_tested:
-            command = "archive -a {} -o {}".format(student_file, student_name)
+            command = "archive -a {} -o {}".format(student_file, username)
             helper.run_command(command, universal_newlines=True)
 
 

--- a/$common/runfile.py
+++ b/$common/runfile.py
@@ -80,7 +80,7 @@ def main():
 
     # handle compilation errors
     # For teaching assistant that test some tasks might want the full feedback
-    full_log = config["has_feedback"] and username == config["username_for_full_log"]
+    full_log = username == config["username_for_full_log"]
     feedback.compilation_feedback(result, full_log)
 
     #####################################

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -133,6 +133,16 @@ def validations(feedback_settings, folder, items_in_task):
             return text_with_color("username_for_full_log should be a string", 196) + "\n"
         else:
             return ""
+        if not isinstance(feedback_settings["usernames_for_full_log"], list):
+            return text_with_color("usernames_for_full_log should be a sequence of string", 196) + "\n"
+        else:
+            if any([
+                    (not isinstance(item, str))
+                    for item in feedback_settings["usernames_for_full_log"]
+            ]):
+                return text_with_color("At least not a string value inside usernames_for_full_log", 196) + "\n"
+            else:
+                return ""
 
     return iter([
         verification_result("feedback_kind", feedback_kind_check),

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -129,10 +129,6 @@ def validations(feedback_settings, folder, items_in_task):
                 return ""
 
     def username_check():
-        if not isinstance(feedback_settings["usernames_for_full_log"], str):
-            return text_with_color("usernames_for_full_log should be a string", 196) + "\n"
-        else:
-            return ""
         if not isinstance(feedback_settings["usernames_for_full_log"], list):
             return text_with_color("usernames_for_full_log should be a sequence of string", 196) + "\n"
         else:

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -128,6 +128,12 @@ def validations(feedback_settings, folder, items_in_task):
             else:
                 return ""
 
+    def username_check():
+        if not isinstance(feedback_settings["username_for_full_log"], str):
+            return text_with_color("username_for_full_log should be a string", 196) + "\n"
+        else:
+            return ""
+
     return iter([
         verification_result("feedback_kind", feedback_kind_check),
         verification_result("quorum", quorum_check),
@@ -137,7 +143,8 @@ def validations(feedback_settings, folder, items_in_task):
         verification_result("plagiarism", plagiarism_check),
         verification_result("external_libraries", external_libraries_check),
         verification_result("custom_feedback_script", custom_feedback_script_check),
-        verification_result("status_message", status_message_check)
+        verification_result("status_message", status_message_check),
+        verification_result("username_for_full_log", username_check)
     ])
 
 

--- a/check_requirements.py
+++ b/check_requirements.py
@@ -129,8 +129,8 @@ def validations(feedback_settings, folder, items_in_task):
                 return ""
 
     def username_check():
-        if not isinstance(feedback_settings["username_for_full_log"], str):
-            return text_with_color("username_for_full_log should be a string", 196) + "\n"
+        if not isinstance(feedback_settings["usernames_for_full_log"], str):
+            return text_with_color("usernames_for_full_log should be a string", 196) + "\n"
         else:
             return ""
         if not isinstance(feedback_settings["usernames_for_full_log"], list):


### PR DESCRIPTION
Hello LEPL1402,

What was done in this PR ?
-
- Simplify compilation_feedback by delegate errors table generation to new function "generate_compilation_errors_table"
- generate_compilation_errors_table has a "allowed_sources" parameter to choose what to display

For example : 

```python
# Will generate a RST table with ONLY student errors (the ones in files in "templates" directory)
generate_compilation_errors_table(errors, [PATH_TEMPLATES])
# Other possibility - when a teacher assistant wants to debug a task he/she is creating
generate_compilation_errors_table(errors, [PATH_TEMPLATES, PATH_SRC, PATH_FLAVOUR])
```
- Add a mechanism to display full errors table for allowed user (useful if a teaching assistant wants to modify / create directly a task on inginious)

Simple add this inside your feedback_settings.yaml : 
```yaml
usernames_for_full_log: 
  - jyakoub
```

Checklist :
✔️ doesn't break backwards
❌ add documentation about that in [feedback_settings.yaml page](https://github.com/UCL-INGI/LEPL1402/wiki/FAQ-on-feedback_settings.yaml)
 🚧 need to be tested in real life : since Inginious seems to have some problems with the [java8scala environment](https://github.com/UCL-INGI/INGInious-containers/tree/master/grading/java8scala), whatever the version I used (v5 or v6), cannot test myself 👎