### PR TITLE
Fix for `NullPointerException` in `Binary trees - combineWith` exercise

### DIFF
--- a/TreeCombineWith/src/Node.java
+++ b/TreeCombineWith/src/Node.java
@@ -1,5 +1,7 @@
 package src;
 
+import java.util.Objects;
+
 public class Node {
 
     public int val;
@@ -22,15 +24,10 @@ public class Node {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Node)) return false;
-
-        Node other = (Node) o;
-
-        if (this.val != other.val) return false;
-        if (this.isLeaf() != other.isLeaf()) return false;
-        if (this.left != null && !this.left.equals(other.left)) return false;
-        if (this.right != null && !this.right.equals(other.right)) return false;
-
-        return true;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        
+        Node node = (Node) o;
+        return val == node.val && Objects.equals(left, node.left) && Objects.equals(right, node.right);
     }
 }


### PR DESCRIPTION
Running the `equals` method on nodes having only one child causes the program to throw a `NullPointerException`.

![](https://user-images.githubusercontent.com/49590979/195326477-35f42b3b-8e2f-440d-a243-74b32c022aec.png)
